### PR TITLE
Make vector template-polymorphic again

### DIFF
--- a/theories/Data/Vector.v
+++ b/theories/Data/Vector.v
@@ -4,15 +4,16 @@ Set Implicit Arguments.
 Set Strict Implicit.
 Set Asymmetric Patterns.
 
+Inductive vector T : nat -> Type :=
+| Vnil : vector T 0
+| Vcons : forall {n}, T -> vector T n -> vector T (S n).
+
 Section parametric.
   Variable T : Type.
 
-  Inductive vector : nat -> Type :=
-  | Vnil : vector 0
-  | Vcons : forall {n}, T -> vector n -> vector (S n).
 
-  Definition vector_hd n (v : vector (S n)) : T :=
-    match v in vector n' return match n' with
+  Definition vector_hd n (v : vector T (S n)) : T :=
+    match v in vector _ n' return match n' with
                                   | 0 => unit
                                   | S _ => T
                                 end with
@@ -20,38 +21,38 @@ Section parametric.
       | Vcons _ x _ => x
     end.
 
-  Definition vector_tl n (v : vector (S n)) : vector n :=
-    match v in vector n' return match n' with
+  Definition vector_tl n (v : vector T (S n)) : vector T n :=
+    match v in vector _ n' return match n' with
                                   | 0 => unit
-                                  | S n => vector n
+                                  | S n => vector T n
                                 end with
       | Vnil => tt
       | Vcons _ _ x => x
     end.
 
-  Theorem vector_eta : forall n (v : vector n),
-                         v = match n as n return vector n -> vector n with
-                               | 0 => fun _ => Vnil
+  Theorem vector_eta : forall n (v : vector T n),
+                         v = match n as n return vector T n -> vector T n with
+                               | 0 => fun _ => Vnil _
                                | S n => fun v => Vcons (vector_hd v) (vector_tl v)
                              end v.
   Proof.
     destruct v; auto.
   Qed.
 
-  Fixpoint get {n : nat} (f : fin n) : vector n -> T :=
-    match f in fin n return vector n -> T with
+  Fixpoint get {n : nat} (f : fin n) : vector T n -> T :=
+    match f in fin n return vector T n -> T with
       | F0 n => @vector_hd _
       | FS n f => fun v => get f (vector_tl v)
     end.
 
-  Fixpoint put {n : nat} (f : fin n) (t : T) : vector n -> vector n :=
-    match f in fin n return vector n -> vector n with
+  Fixpoint put {n : nat} (f : fin n) (t : T) : vector T n -> vector T n :=
+    match f in fin n return vector T n -> vector T n with
       | F0 _ => fun v => Vcons t (vector_tl v)
       | FS _ f => fun v => Vcons (vector_hd v) (put f t (vector_tl v))
     end.
 
 
-  Theorem get_put_eq : forall {n} (v : vector n) (f : fin n) val,
+  Theorem get_put_eq : forall {n} (v : vector T n) (f : fin n) val,
                          get f (put f val v) = val.
   Proof.
     induction n.
@@ -61,7 +62,7 @@ Section parametric.
       inversion Heqn0; subst; simpl; auto. }
   Qed.
 
-  Theorem get_put_neq : forall {n} (v : vector n) (f f' : fin n) val,
+  Theorem get_put_neq : forall {n} (v : vector T n) (f f' : fin n) val,
                           f <> f' ->
                           get f (put f' val v) = get f v.
   Proof.
@@ -81,12 +82,12 @@ Section parametric.
   Section ForallV.
     Variable P : T -> Prop.
 
-    Inductive ForallV  : forall n, vector n -> Prop :=
-    | ForallV_nil : ForallV Vnil
+    Inductive ForallV  : forall n, vector T n -> Prop :=
+    | ForallV_nil : ForallV (Vnil _)
     | ForallV_cons : forall n e es, P e -> @ForallV n es -> ForallV (Vcons e es).
 
-    Definition ForallV_vector_hd n (v : vector (S n)) (f : ForallV v) : P (vector_hd v) :=
-      match f in @ForallV n v return match n as n return vector n -> Prop with
+    Definition ForallV_vector_hd n (v : vector T (S n)) (f : ForallV v) : P (vector_hd v) :=
+      match f in @ForallV n v return match n as n return vector T n -> Prop with
                                        | 0 => fun _ => True
                                        | S _ => fun v => P (vector_hd v)
                                      end v
@@ -95,8 +96,8 @@ Section parametric.
         | ForallV_cons _ _ _ pf _ => pf
       end.
 
-    Definition ForallV_vector_tl n (v : vector (S n)) (f : ForallV v) : ForallV (vector_tl v) :=
-      match f in @ForallV n v return match n as n return vector n -> Prop with
+    Definition ForallV_vector_tl n (v : vector T (S n)) (f : ForallV v) : ForallV (vector_tl v) :=
+      match f in @ForallV n v return match n as n return vector T n -> Prop with
                                        | 0 => fun _ => True
                                        | S _ => fun v => ForallV (vector_tl v)
                                      end v
@@ -109,18 +110,18 @@ Section parametric.
   Section vector_dec.
     Variable Tdec : forall a b : T, {a = b} + {a <> b}.
 
-    Fixpoint vector_dec {n} (a : vector n)
-      : forall b : vector n, {a = b} + {a <> b} :=
-      match a in vector n
-            return forall b : vector n, {a = b} + {a <> b}
+    Fixpoint vector_dec {n} (a : vector T n)
+      : forall b : vector T n, {a = b} + {a <> b} :=
+      match a in vector _ n
+            return forall b : vector T n, {a = b} + {a <> b}
       with
-      | Vnil => fun b => left match b in vector 0 with
+      | Vnil => fun b => left match b in vector _ 0 with
                                 | Vnil => eq_refl
                                 end
       | Vcons _ a a' => fun b =>
-        match b as b in vector (S n)
+        match b as b in vector _ (S n)
               return forall a',
-                (forall a : vector n, {a' = a} + {a' <> a}) ->
+                (forall a : vector T n, {a' = a} + {a' <> a}) ->
                 {Vcons a a' = b} + {Vcons a a' <> b}
         with
         | Vcons _ b b' => fun a' rec =>
@@ -150,13 +151,13 @@ Section parametric.
 
   Section vector_in.
     Variable a : T.
-    Inductive vector_In : forall {n}, vector n -> Prop :=
+    Inductive vector_In : forall {n}, vector T n -> Prop :=
     | vHere : forall n rst, @vector_In (S n) (Vcons a rst)
     | vNext : forall n rst b, @vector_In n rst ->
                               @vector_In (S n) (Vcons b rst).
   End vector_in.
 
-  Lemma ForallV_vector_In : forall {n} t (vs : vector n) P,
+  Lemma ForallV_vector_In : forall {n} t (vs : vector T n) P,
       ForallV P vs ->
       vector_In t vs -> P t.
   Proof.


### PR DESCRIPTION
After coq/coq#9918, vector was no-longer template polymorphic.  This
backwards-compatible commit fixes that.

Note that this is required for mirror-core to build with Coq v8.10 without universe errors.