### PR TITLE
overlay for coq/coq#12008

### DIFF
--- a/examples/ConsiderDemo.v
+++ b/examples/ConsiderDemo.v
@@ -1,7 +1,7 @@
+Require Import Coq.Bool.Bool.
 Require NPeano.
 Import NPeano.Nat.
 Require Import ExtLib.Tactics.Consider.
-Require Import Coq.Bool.Bool.
 Require Import ExtLib.Data.Nat.
 
 Require Import Coq.ZArith.ZArith.


### PR DESCRIPTION
coq/coq#12008 introduces a new `Bool.ltb` with potential conflicts with `Nat.ltb` when `ltb` is not qualifed enough.