### PR TITLE
Regenerate files from latest templates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI][circleci-shield]][circleci-link]
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
-[![Gitter][gitter-shield]][gitter-link]
+[![Zulip][zulip-shield]][zulip-link]
 
 [circleci-shield]: https://circleci.com/gh/coq-community/coq-ext-lib.svg?style=svg
 [circleci-link]:   https://circleci.com/gh/coq-community/coq-ext-lib
@@ -14,8 +14,8 @@
 [conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
 [conduct-link]: https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
 
-[gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
-[gitter-link]: https://gitter.im/coq-community/Lobby
+[zulip-shield]: https://img.shields.io/badge/chat-on%20zulip-%23c1272d.svg
+[zulip-link]: https://coq.zulipchat.com/#narrow/stream/237663-coq-community-devs.20.26.20users
 
 
 
@@ -47,7 +47,7 @@ opam install coq-ext-lib
 To instead build and install manually, do:
 
 ``` shell
-git clone https://github.com/coq-community/coq-ext-lib
+git clone https://github.com/coq-community/coq-ext-lib.git
 cd coq-ext-lib
 make theories  # or make -j <number-of-cores-on-your-machine> theories
 make install

--- a/meta.yml
+++ b/meta.yml
@@ -37,7 +37,7 @@ tested_coq_opam_versions:
   - version: '8.11'
   - version: 'dev'
 
-target: theories
+make_target: theories
 namespace: ExtLib
 
 documentation: |


### PR DESCRIPTION
Includes a move from the Gitter badge to the Zulip badge in README.

Note: we are not there yet regarding the CircleCI template nor the
opam file to allow regenerating these files blindly, but the
coq-ext-lib/templates fork no longer contains anything that cannot be
achieved with coq-community/templates.
