### PR TITLE
Fun functors visibility

### DIFF
--- a/theories/Data/Fun.v
+++ b/theories/Data/Fun.v
@@ -11,11 +11,7 @@ Set Strict Implicit.
 Section functors.
   Variable A : Type.
 
-  Instance FunFunctor A : Functor (Fun A) :=
-  { fmap _A _B g f x := g (f x)
-  }.
-
-  Local Instance Functor_Fun : Functor (Fun A) :=
+  Global Instance Functor_Fun : Functor (Fun A) :=
   { fmap _A _B g f x := g (f x) }.
 
   Local Instance CoFunctor_Fun T : CoFunctor (fun x => x -> T) :=

--- a/theories/Data/Fun.v
+++ b/theories/Data/Fun.v
@@ -29,7 +29,7 @@ Section functors.
   Local Instance CoFunctor_cofunctor F G (fF : CoFunctor F) (fG : CoFunctor G) : Functor (fun x => F (G x)) :=
   {| fmap := fun _ _ g => @cofmap F _ _ _ (@cofmap G _ _ _ g) |}.
 
-  Instance Applicative_Fun : Applicative (Fun A) :=
+  Global Instance Applicative_Fun : Applicative (Fun A) :=
   { pure := fun _ x _ => x
   ; ap := fun _ _ f x y => (f y) (x y)
   }.

--- a/theories/Data/Fun.v
+++ b/theories/Data/Fun.v
@@ -33,7 +33,7 @@ Section functors.
   Local Instance CoFunctor_cofunctor F G (fF : CoFunctor F) (fG : CoFunctor G) : Functor (fun x => F (G x)) :=
   {| fmap := fun _ _ g => @cofmap F _ _ _ (@cofmap G _ _ _ g) |}.
 
-  Local Instance Applicative_Fun : Applicative (Fun A) :=
+  Instance Applicative_Fun : Applicative (Fun A) :=
   { pure := fun _ x _ => x
   ; ap := fun _ _ f x y => (f y) (x y)
   }.


### PR DESCRIPTION
https://github.com/coq-community/coq-ext-lib/issues/88

- `Functor_Fun` and `Applicative_Fun` instances are global
- Removed duplicate instance for `Functor (Fun A)`