### PR TITLE
Don't fail if coqdocjs not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: theories examples
 
-include coqdocjs/Makefile.doc
+-include coqdocjs/Makefile.doc
 
 theories: $(COQMAKEFILE)
 	$(MAKE) -f $(COQMAKEFILE)


### PR DESCRIPTION
For instance in Coq's CI we don't setup submodules (it's faster to just download the tarball from github)