### PR TITLE
Fix StateGame.v example

### DIFF
--- a/examples/StateGame.v
+++ b/examples/StateGame.v
@@ -13,7 +13,7 @@
        = (Bool, Int)
  *)
 
-Require Import Coq.ZArith.ZArith_base Coq.Strings.String.
+Require Import Coq.ZArith.ZArith_base Coq.Strings.String Coq.Strings.Ascii.
 Require Import ExtLib.Data.Monads.StateMonad ExtLib.Structures.Monads.
 
 Section StateGame.


### PR DESCRIPTION
Doing some "smoke tests" on the Coq platform I found that the StateGame.v example no longer works - i think cause of changes in recursive requires in Coq. This PR provides a simple fix.