### PR TITLE
Make Monad_stateT a local instance

### DIFF
--- a/examples/StateTMonad.v
+++ b/examples/StateTMonad.v
@@ -3,13 +3,13 @@ From ExtLib Require Import
      OptionMonad
      StateMonad.
 
-(* Monad_stateT is not in context, so this definition fails *)
+(** [Monad_stateT] is not in context, so this definition fails *)
 Fail Definition foo : stateT unit option unit :=
   ret tt.
 
-(* Use Existing Instance to bring the Local Monad_stateT instance into context *)
+(** Use [Existing Instance] to bring the Local [Monad_stateT] instance into context *)
 Existing Instance Monad_stateT.
 
-(* Now the definition succeeds *)
+(** Now the definition succeeds *)
 Definition foo : stateT unit option unit :=
   ret tt.

--- a/examples/StateTMonad.v
+++ b/examples/StateTMonad.v
@@ -1,0 +1,15 @@
+From ExtLib Require Import
+     Monad
+     OptionMonad
+     StateMonad.
+
+(* Monad_stateT is not in context, so this definition fails *)
+Fail Definition foo : stateT unit option unit :=
+  ret tt.
+
+(* Use Existing Instance to bring the Local Monad_stateT instance into context *)
+Existing Instance Monad_stateT.
+
+(* Now the definition succeeds *)
+Definition foo : stateT unit option unit :=
+  ret tt.

--- a/examples/_CoqProject
+++ b/examples/_CoqProject
@@ -8,3 +8,4 @@ Printing.v
 UsingSets.v
 WithDemo.v
 Notations.v
+StateTMonad.v

--- a/theories/Data/Monads/StateMonad.v
+++ b/theories/Data/Monads/StateMonad.v
@@ -43,7 +43,9 @@ Section StateType.
   Definition execStateT {t} (c : stateT t) (s : S) : m S :=
     bind (runStateT c s) (fun x => ret (snd x)).
 
-
+  (* Monad_stateT is not a Global Instance because it can cause an infinite loop
+     in typeclass inference under certain circumstances. Use "Existing Instance
+     Monad_stateT" to bring the instance into context. *)
   Instance Monad_stateT : Monad stateT :=
   { ret := fun _ x => mkStateT (fun s => @ret _ M _ (x,s))
   ; bind := fun _ _ c1 c2 =>

--- a/theories/Data/Monads/StateMonad.v
+++ b/theories/Data/Monads/StateMonad.v
@@ -43,9 +43,9 @@ Section StateType.
   Definition execStateT {t} (c : stateT t) (s : S) : m S :=
     bind (runStateT c s) (fun x => ret (snd x)).
 
-  (* Monad_stateT is not a Global Instance because it can cause an infinite loop
-     in typeclass inference under certain circumstances. Use "Existing Instance
-     Monad_stateT" to bring the instance into context. *)
+  (** [Monad_stateT] is not a Global Instance because it can cause an infinite loop
+     in typeclass inference under certain circumstances. Use [Existing Instance
+     Monad_stateT.] to bring the instance into context. *)
   Instance Monad_stateT : Monad stateT :=
   { ret := fun _ x => mkStateT (fun s => @ret _ M _ (x,s))
   ; bind := fun _ _ c1 c2 =>

--- a/theories/Data/Monads/StateMonad.v
+++ b/theories/Data/Monads/StateMonad.v
@@ -44,7 +44,7 @@ Section StateType.
     bind (runStateT c s) (fun x => ret (snd x)).
 
 
-  Global Instance Monad_stateT : Monad stateT :=
+  Instance Monad_stateT : Monad stateT :=
   { ret := fun _ x => mkStateT (fun s => @ret _ M _ (x,s))
   ; bind := fun _ _ c1 c2 =>
     mkStateT (fun s =>


### PR DESCRIPTION
Because `Monad_stateT` requires a monad argument, it can in some situations create infinite loops in typeclass resolution. My minimized example of the problem:
```
Require Import Structures.Monad.
Require Import Data.Monads.StateMonad.

Class A (proj : nat -> Type):=
  { m : Type -> Type;
    x : m (proj 1);
  }.

Definition hangs {proj} {a : A proj} {monad : Monad.Monad m} : m (proj 1) := ret x. (* infinite loop *)
```
The `hangs` definition is not properly typed (it has type `m (m (proj 1)`), but I'd still prefer to get a typeclass-resolution error here than to get an infinite loop. The trace from `Typeclasses Debug` is:
```
Debug: 1: looking for (A ?proj) with backtracking
Debug: 1.1: exact a on (A ?proj), 0 subgoal(s)
Debug: Finished run 1 of resolution.
Debug: 1: looking for (A ?proj) with backtracking
Debug: 1.1: exact a on (A ?proj), 0 subgoal(s)
Debug: Finished run 1 of resolution.
Debug: 1: looking for (Monad ?m) with backtracking
Debug: 1.1: simple apply Monad_state on (Monad ?m), 0 subgoal(s)
Debug: 2: looking for (A ?proj) with backtracking
Debug: 2: no match for (A ?proj), 1 possibilities
Debug: 1.2: simple apply Monad_stateT on (Monad ?m), 1 subgoal(s)
Debug: 1.2-1 : (Monad ?Goal0)
Debug: 1.2-1: looking for (Monad ?Goal0) with backtracking
Debug: 1.2-1.1: simple apply Monad_state on (Monad ?Goal0), 0 subgoal(s)
Debug: 2: looking for (A ?proj) with backtracking
Debug: 2: no match for (A ?proj), 1 possibilities
Debug: 1.2-1.2: simple apply Monad_stateT on (Monad ?Goal0), 1 subgoal(s)
Debug: 1.2-1.2-1 : (Monad ?Goal1)
Debug: 1.2-1.2-1: looking for (Monad ?Goal1) with backtracking
Debug: 1.2-1.2-1.1: simple apply Monad_state on (Monad ?Goal1), 0 subgoal(s)
Debug: 2: looking for (A ?proj) with backtracking
Debug: 2: no match for (A ?proj), 1 possibilities
Debug: 1.2-1.2-1.2: simple apply Monad_stateT on (Monad ?Goal1), 1 subgoal(s)
Debug: 1.2-1.2-1.2-1 : (Monad ?Goal2)
... <many more lines with the same pattern> ...
```
Removing the `Global` modifier from  `Monad_stateT` locally fixes this issue for me, giving me the expected typeclass resolution error instead of the infinite loop. Although the rest of the `Monad` instances are `Global`, I think that it might make sense to make an exception for this one. 