### PR TITLE
Fix for Coq PR 13986

### DIFF
--- a/theories/Data/ListNth.v
+++ b/theories/Data/ListNth.v
@@ -1,4 +1,5 @@
 Require Import Coq.Lists.List.
+Require Import Coq.Arith.Lt Coq.Arith.Plus.
 
 Set Implicit Arguments.
 Set Strict Implicit.


### PR DESCRIPTION
In an effort https://github.com/coq/coq/pull/13986 to streamline Coq's `List.v`, dependencies on `Arith` modules are removed.
Therefore, importing `List` will not provide `Arith` functionality. Resulting issues are fixed by this PR.