### PR TITLE
Support compilation using [dune].

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_build/
 *.vo
 *.glob
 *.v.d

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.8)
+(using coq 0.8)

--- a/examples/dune
+++ b/examples/dune
@@ -1,0 +1,4 @@
+(include_subdirs qualified)
+(coq.theory
+ (name ExtLibExamples)
+ (theories ExtLib))

--- a/theories/Generic/Ind.v
+++ b/theories/Generic/Ind.v
@@ -1,4 +1,4 @@
-Require Import List String.
+From Coq Require Import List String.
 Require Import ExtLib.Structures.CoMonad.
 
 Set Implicit Arguments.

--- a/theories/dune
+++ b/theories/dune
@@ -1,0 +1,4 @@
+(include_subdirs qualified)
+(coq.theory
+ (name ExtLib)
+ (package coq-ext-lib))


### PR DESCRIPTION
This is the minimal change required to be integrate `coq-ext-lib` in a dune workspace.

What is not included:
- Testing dune compilation in CI.
- Support for editors while compiling with `dune`.